### PR TITLE
fix: thruster bind issue

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,7 +37,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 # Bind to both IPv4 and IPv6 so Thruster (which connects via [::1]) can reach Puma.
-port_number = ENV.fetch("PORT", 3000)
+port_number = ENV.fetch('PORT', 3000)
 bind "tcp://0.0.0.0:#{port_number}"
 bind "tcp://[::1]:#{port_number}"
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,7 +36,10 @@ threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch('PORT', 3000)
+# Bind to both IPv4 and IPv6 so Thruster (which connects via [::1]) can reach Puma.
+port_number = ENV.fetch("PORT", 3000)
+bind "tcp://0.0.0.0:#{port_number}"
+bind "tcp://[::1]:#{port_number}"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
**fix: bind Puma to IPv6 loopback so Thruster health checks pass**

## Problem

Deployments were failing at the Kamal health check stage with:

```
Unable to proxy request  path=/up  error="dial tcp [::1]:3000: connect: connection refused"
```

Thruster (the HTTP proxy that sits in front of Puma inside the container) connects to Puma via the IPv6 loopback address `[::1]:3000`. Puma was only bound to `0.0.0.0:3000` (IPv4 wildcard), so Thruster's connection attempts were refused, the `/up` health check never returned 200, and Kamal timed out after 30 s and rolled back.

## Solution

Replace the single `port` directive in puma.rb with explicit `bind` calls for both IPv4 (`0.0.0.0`) and IPv6 (`[::1]`) on the same port number. This ensures Puma is reachable regardless of whether the caller uses IPv4 or IPv6.

## Changes

- puma.rb — swap `port ENV.fetch('PORT', 3000)` for two `bind` directives covering `0.0.0.0` and `[::1]`

## Testing

- `bin/kamal deploy` completes successfully; Kamal health check passes within the 30 s window.