### PR TITLE
fix: prevent Kamal health check timeout caused by hanging DB connections on boot

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -30,6 +30,8 @@ production:
     adapter: postgresql
     encoding: unicode
     pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+    connect_timeout: 5
+    checkout_timeout: 5
     host: <%= ENV.fetch("POSTGRES_HOST", "localhost") %>
     username: <%= ENV.fetch("POSTGRES_USER", "postgres") %>
     password: <%= ENV["POSTGRES_PASSWORD"] %>


### PR DESCRIPTION
## Problem

Deployments were failing the Kamal health check with:

```
Error: target failed to become healthy within configured timeout (30s)
```

However, the app was actually starting successfully — just very slowly. Logs showed the `/up` health check hanging for **~908 seconds** (~15 minutes) before returning a 502, at which point Kamal stopped the container.

## Root Cause

The hang was caused by SolidQueue initialising **in-process inside Puma** (via `plugin :solid_queue` in `puma.rb`, enabled by `SOLID_QUEUE_IN_PUMA: true`). During boot, SolidQueue attempts to open a TCP connection to the `zurno_doc-db` PostgreSQL container. If that connection hangs at the OS level (no TCP RST, no response — common during rolling deploys when the DB container is briefly unreachable), it blocks indefinitely using the default OS TCP timeout (~15 minutes).

Because SolidQueue's initialisation blocks Puma's thread pool from becoming fully ready, the `/up` health check endpoint cannot be served, causing Kamal to time out and stop the container.

The timing correlation in the logs confirms this — SolidQueue's Supervisor, Worker, and Dispatcher all started at the exact millisecond the health check hang resolved (908,489ms).

## Fix

Added `connect_timeout` and `checkout_timeout` to the `&production_default` anchor in `config/database.yml`. Both values inherit to all four production databases (`primary`, `queue`, `cache`, `cable`) via YAML anchor inheritance.

```yaml
connect_timeout: 5    # PostgreSQL-level: TCP connection to DB fails fast (5s) instead of hanging for OS timeout (~15min)
checkout_timeout: 5   # Rails pool-level: thread waiting for a free pool connection raises after 5s
```

With this change, if the DB is momentarily unreachable during boot, SolidQueue's connection attempt fails in 5 seconds, it retries, and Puma becomes responsive well within Kamal's 30-second health check window.

## Why not run SolidQueue in a separate container?

The server has 1 GB RAM and 1 vCPU. A separate container would require a second full Rails boot (~150 MB additional RSS), risking swap under load. The current in-Puma architecture is the right choice for these constraints — the boot-time hang was the only issue, and it is now addressed with fast-fail timeouts.

## Changes

- `config/database.yml` — added `connect_timeout: 5` and `checkout_timeout: 5` to `&production_default`
