### PR TITLE
Make boxes in patient view collapsible

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,13 @@ rubocop             # check remaining offenses (fix manually)
 - TargetRubyVersion is 4.0.
 - Always use **LF** line endings (`\n`) when creating or editing `.rb` files. CRLF (`\r\n`) will cause a `Layout/EndOfLine` rubocop offense.
 
+## GitHub Access
+
+- The `gh` CLI is **not available** in this dev container. Do not attempt to use it.
+- GitHub operations (creating PRs, fetching issues, etc.) must be done via the **MCP GitHub tools** (`mcp_io_github_git_*`), which are available to Copilot agents.
+- Repository: `amfurno/ZurnoDoc` — owner `amfurno`, repo `ZurnoDoc`.
+- Issue and PR details can also be fetched from the GitHub REST API: `https://api.github.com/repos/amfurno/ZurnoDoc/issues/<number>`.
+
 ## CI Pipeline
 
 Five GitHub Actions jobs (all run from `zurnoDoc/`):

--- a/app/assets/stylesheets/application.bulma.scss
+++ b/app/assets/stylesheets/application.bulma.scss
@@ -37,3 +37,4 @@
 // @import "bulma/sass/layout/section.sass";
 
 @import 'bulma/bulma';
+@import 'collapsible';

--- a/app/assets/stylesheets/collapsible.scss
+++ b/app/assets/stylesheets/collapsible.scss
@@ -1,0 +1,11 @@
+.collapsible-header {
+  cursor: pointer;
+}
+
+.collapsible-icon {
+  font-weight: normal;
+}
+
+.collapsible-actions {
+  gap: 0.5rem;
+}

--- a/app/javascript/controllers/collapsible_controller.js
+++ b/app/javascript/controllers/collapsible_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "icon"]
+  static values = { key: String, expanded: { type: Boolean, default: true } }
+
+  connect() {
+    const stored = localStorage.getItem(this.storageKey)
+    if (stored !== null) {
+      this.expandedValue = stored === "true"
+    }
+    this.applyState()
+  }
+
+  toggle() {
+    this.expandedValue = !this.expandedValue
+    localStorage.setItem(this.storageKey, this.expandedValue)
+    this.applyState()
+  }
+
+  stopPropagation(event) {
+    event.stopPropagation()
+  }
+
+  applyState() {
+    if (this.expandedValue) {
+      this.contentTarget.classList.remove("is-hidden")
+      this.iconTarget.textContent = "−"
+    } else {
+      this.contentTarget.classList.add("is-hidden")
+      this.iconTarget.textContent = "+"
+    }
+  }
+
+  get storageKey() {
+    return `collapsible-${this.keyValue}`
+  }
+}

--- a/app/javascript/controllers/collapsible_controller.js
+++ b/app/javascript/controllers/collapsible_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["content", "icon"]
+  static targets = ["content", "icon", "header"]
   static values = { key: String, expanded: { type: Boolean, default: true } }
 
   connect() {
@@ -23,9 +23,11 @@ export default class extends Controller {
   }
 
   applyState() {
-    if (this.expandedValue) {
+    const expanded = this.expandedValue
+    this.headerTarget.setAttribute("aria-expanded", expanded)
+    if (expanded) {
       this.contentTarget.classList.remove("is-hidden")
-      this.iconTarget.textContent = "−"
+      this.iconTarget.textContent = "-"
     } else {
       this.contentTarget.classList.add("is-hidden")
       this.iconTarget.textContent = "+"

--- a/app/views/patients/_section_box.html.erb
+++ b/app/views/patients/_section_box.html.erb
@@ -1,8 +1,13 @@
 <%# locals: (title:, key:, actions: nil) %>
 <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="<%= key %>">
-  <div class="level collapsible-header" data-action="click->collapsible#toggle">
+  <div class="level collapsible-header"
+       role="button"
+       tabindex="0"
+       aria-expanded="true"
+       data-collapsible-target="header"
+       data-action="click->collapsible#toggle keydown.enter->collapsible#toggle keydown.space->collapsible#toggle">
     <div class="level-left">
-      <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2 collapsible-icon">−</span><%= title %></h2>
+      <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2 collapsible-icon">-</span><%= title %></h2>
     </div>
     <% if actions.present? %>
       <div class="level-right collapsible-actions">

--- a/app/views/patients/_section_box.html.erb
+++ b/app/views/patients/_section_box.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (title:, key:, actions: nil) %>
+<div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="<%= key %>">
+  <div class="level collapsible-header" data-action="click->collapsible#toggle">
+    <div class="level-left">
+      <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2 collapsible-icon">−</span><%= title %></h2>
+    </div>
+    <% if actions.present? %>
+      <div class="level-right collapsible-actions">
+        <%= actions %>
+      </div>
+    <% end %>
+  </div>
+  <div data-collapsible-target="content">
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -10,90 +10,69 @@
 
     <%# Doctors %>
     <div class="column">
-      <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="doctors">
-        <div class="level" style="cursor: pointer;" data-action="click->collapsible#toggle">
-          <div class="level-left">
-            <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2" style="font-weight: normal;">−</span>Doctors</h2>
-          </div>
-          <div class="level-right" style="gap: 0.5rem;">
-            <%= link_to "View All", patient_doctors_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
-            <%= link_to "Add Doctor", new_patient_doctor_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
-          </div>
-        </div>
-        <div data-collapsible-target="content">
-          <% if @patient.doctors.any? %>
-            <% @patient.doctors.order(updated_at: :desc).limit(5).each do |doctor| %>
-              <div class="box">
-                <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
-                  <div class="level-left is-flex-grow-1" style="min-width: 0;">
-                    <div>
-                      <p class="has-text-weight-bold"><%= doctor.name %></p>
-                      <p class="is-size-6"><%= doctor.practice %></p>
-                      <p class="is-size-6 has-text-grey"><%= doctor.speciality %></p>
-                    </div>
-                  </div>
-                  <div class="level-right">
-                    <%= link_to "View", patient_doctor_path(@patient, doctor), class: "button is-info is-small" %>
+      <% doctors_actions = capture do %>
+        <%= link_to "View All", patient_doctors_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
+        <%= link_to "Add Doctor", new_patient_doctor_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
+      <% end %>
+      <%= render layout: "patients/section_box", locals: { title: "Doctors", key: "doctors", actions: doctors_actions } do %>
+        <% if @patient.doctors.any? %>
+          <% @patient.doctors.order(updated_at: :desc).limit(5).each do |doctor| %>
+            <div class="box">
+              <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
+                <div class="level-left is-flex-grow-1" style="min-width: 0;">
+                  <div>
+                    <p class="has-text-weight-bold"><%= doctor.name %></p>
+                    <p class="is-size-6"><%= doctor.practice %></p>
+                    <p class="is-size-6 has-text-grey"><%= doctor.speciality %></p>
                   </div>
                 </div>
+                <div class="level-right">
+                  <%= link_to "View", patient_doctor_path(@patient, doctor), class: "button is-info is-small" %>
+                </div>
               </div>
-            <% end %>
-          <% else %>
-            <p class="has-text-grey">No doctors added yet.</p>
+            </div>
           <% end %>
-        </div>
-      </div>
+        <% else %>
+          <p class="has-text-grey">No doctors added yet.</p>
+        <% end %>
+      <% end %>
     </div>
 
     <%# Medications %>
     <div class="column">
-      <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="medications">
-        <div class="level" style="cursor: pointer;" data-action="click->collapsible#toggle">
-          <div class="level-left">
-            <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2" style="font-weight: normal;">−</span>Medications</h2>
-          </div>
-          <div class="level-right" style="gap: 0.5rem;">
-            <%= link_to "View All", patient_medications_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
-            <%= link_to "Add Medication", new_patient_medication_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
-          </div>
-        </div>
-        <div data-collapsible-target="content">
-          <% if @patient.medications.any? %>
-            <% @patient.medications.includes(:doctor).order(updated_at: :desc).where(date_stopped: nil).limit(5).each do |medication| %>
-              <div class="box">
-                <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
-                  <div class="level-left is-flex-grow-1" style="min-width: 0;">
-                    <div>
-                      <p class="has-text-weight-bold"><%= medication.name %></p>
-                      <p class="is-size-6"><%= medication.drug_class %></p>
-                      <p class="is-size-6 has-text-grey"><%= medication.doctor&.name %></p>
-                    </div>
-                  </div>
-                  <div class="level-right">
-                    <%= link_to "View", patient_medication_path(@patient, medication), class: "button is-info is-small" %>
+      <% medications_actions = capture do %>
+        <%= link_to "View All", patient_medications_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
+        <%= link_to "Add Medication", new_patient_medication_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
+      <% end %>
+      <%= render layout: "patients/section_box", locals: { title: "Medications", key: "medications", actions: medications_actions } do %>
+        <% if @patient.medications.any? %>
+          <% @patient.medications.includes(:doctor).order(updated_at: :desc).where(date_stopped: nil).limit(5).each do |medication| %>
+            <div class="box">
+              <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
+                <div class="level-left is-flex-grow-1" style="min-width: 0;">
+                  <div>
+                    <p class="has-text-weight-bold"><%= medication.name %></p>
+                    <p class="is-size-6"><%= medication.drug_class %></p>
+                    <p class="is-size-6 has-text-grey"><%= medication.doctor&.name %></p>
                   </div>
                 </div>
+                <div class="level-right">
+                  <%= link_to "View", patient_medication_path(@patient, medication), class: "button is-info is-small" %>
+                </div>
               </div>
-            <% end %>
-          <% else %>
-            <p class="has-text-grey">No medications added yet.</p>
+            </div>
           <% end %>
-        </div>
-      </div>
+        <% else %>
+          <p class="has-text-grey">No medications added yet.</p>
+        <% end %>
+      <% end %>
     </div>
 
     <%# Visits (placeholder) %>
     <div class="column">
-      <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="visits">
-        <div class="level" style="cursor: pointer;" data-action="click->collapsible#toggle">
-          <div class="level-left">
-            <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2" style="font-weight: normal;">−</span>Visits</h2>
-          </div>
-        </div>
-        <div data-collapsible-target="content">
-          <p class="has-text-grey">Coming soon.</p>
-        </div>
-      </div>
+      <%= render layout: "patients/section_box", locals: { title: "Visits", key: "visits" } do %>
+        <p class="has-text-grey">Coming soon.</p>
+      <% end %>
     </div>
 
   </div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -14,7 +14,7 @@
         <%= link_to "View All", patient_doctors_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
         <%= link_to "Add Doctor", new_patient_doctor_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
       <% end %>
-      <%= render layout: "patients/section_box", locals: { title: "Doctors", key: "doctors", actions: doctors_actions } do %>
+      <%= render layout: "patients/section_box", locals: { title: "Doctors", key: "patient-#{@patient.id}-doctors", actions: doctors_actions } do %>
         <% if @patient.doctors.any? %>
           <% @patient.doctors.order(updated_at: :desc).limit(5).each do |doctor| %>
             <div class="box">
@@ -44,7 +44,7 @@
         <%= link_to "View All", patient_medications_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
         <%= link_to "Add Medication", new_patient_medication_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
       <% end %>
-      <%= render layout: "patients/section_box", locals: { title: "Medications", key: "medications", actions: medications_actions } do %>
+      <%= render layout: "patients/section_box", locals: { title: "Medications", key: "patient-#{@patient.id}-medications", actions: medications_actions } do %>
         <% if @patient.medications.any? %>
           <% @patient.medications.includes(:doctor).order(updated_at: :desc).where(date_stopped: nil).limit(5).each do |medication| %>
             <div class="box">
@@ -70,7 +70,7 @@
 
     <%# Visits (placeholder) %>
     <div class="column">
-      <%= render layout: "patients/section_box", locals: { title: "Visits", key: "visits" } do %>
+      <%= render layout: "patients/section_box", locals: { title: "Visits", key: "patient-#{@patient.id}-visits" } do %>
         <p class="has-text-grey">Coming soon.</p>
       <% end %>
     </div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -10,79 +10,89 @@
 
     <%# Doctors %>
     <div class="column">
-      <div class="box has-background-primary-95">
-        <div class="level">
+      <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="doctors">
+        <div class="level" style="cursor: pointer;" data-action="click->collapsible#toggle">
           <div class="level-left">
-            <h2 class="title is-4">Doctors</h2>
+            <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2" style="font-weight: normal;">−</span>Doctors</h2>
           </div>
-          <div class="level-right">
-            <%= link_to "View All", patient_doctors_path(@patient), class: "button is-info is-small" %>
-            <%= link_to "Add Doctor", new_patient_doctor_path(@patient), class: "button is-primary is-small" %>
+          <div class="level-right" style="gap: 0.5rem;">
+            <%= link_to "View All", patient_doctors_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
+            <%= link_to "Add Doctor", new_patient_doctor_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
           </div>
         </div>
-        <% if @patient.doctors.any? %>
-          <% @patient.doctors.order(updated_at: :desc).limit(5).each do |doctor| %>
-            <div class="box">
-              <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
-                <div class="level-left is-flex-grow-1" style="min-width: 0;">
-                  <div>
-                    <p class="has-text-weight-bold"><%= doctor.name %></p>
-                    <p class="is-size-6"><%= doctor.practice %></p>
-                    <p class="is-size-6 has-text-grey"><%= doctor.speciality %></p>
+        <div data-collapsible-target="content">
+          <% if @patient.doctors.any? %>
+            <% @patient.doctors.order(updated_at: :desc).limit(5).each do |doctor| %>
+              <div class="box">
+                <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
+                  <div class="level-left is-flex-grow-1" style="min-width: 0;">
+                    <div>
+                      <p class="has-text-weight-bold"><%= doctor.name %></p>
+                      <p class="is-size-6"><%= doctor.practice %></p>
+                      <p class="is-size-6 has-text-grey"><%= doctor.speciality %></p>
+                    </div>
+                  </div>
+                  <div class="level-right">
+                    <%= link_to "View", patient_doctor_path(@patient, doctor), class: "button is-info is-small" %>
                   </div>
                 </div>
-                <div class="level-right">
-                  <%= link_to "View", patient_doctor_path(@patient, doctor), class: "button is-info is-small" %>
-                </div>
               </div>
-            </div>
+            <% end %>
+          <% else %>
+            <p class="has-text-grey">No doctors added yet.</p>
           <% end %>
-        <% else %>
-          <p class="has-text-grey">No doctors added yet.</p>
-        <% end %>
+        </div>
       </div>
     </div>
 
     <%# Medications %>
     <div class="column">
-      <div class="box has-background-primary-95">
-        <div class="level">
+      <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="medications">
+        <div class="level" style="cursor: pointer;" data-action="click->collapsible#toggle">
           <div class="level-left">
-            <h2 class="title is-4">Medications</h2>
+            <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2" style="font-weight: normal;">−</span>Medications</h2>
           </div>
-          <div class="level-right">
-            <%= link_to "View All", patient_medications_path(@patient), class: "button is-info is-small" %>
-            <%= link_to "Add Medication", new_patient_medication_path(@patient), class: "button is-primary is-small" %>
+          <div class="level-right" style="gap: 0.5rem;">
+            <%= link_to "View All", patient_medications_path(@patient), class: "button is-info is-small", data: { action: "click->collapsible#stopPropagation" } %>
+            <%= link_to "Add Medication", new_patient_medication_path(@patient), class: "button is-primary is-small", data: { action: "click->collapsible#stopPropagation" } %>
           </div>
         </div>
-        <% if @patient.medications.any? %>
-          <% @patient.medications.includes(:doctor).order(updated_at: :desc).where(date_stopped: nil).limit(5).each do |medication| %>
-            <div class="box">
-              <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
-                <div class="level-left is-flex-grow-1" style="min-width: 0;">
-                  <div>
-                    <p class="has-text-weight-bold"><%= medication.name %></p>
-                    <p class="is-size-6"><%= medication.drug_class %></p>
-                    <p class="is-size-6 has-text-grey"><%= medication.doctor&.name %></p>
+        <div data-collapsible-target="content">
+          <% if @patient.medications.any? %>
+            <% @patient.medications.includes(:doctor).order(updated_at: :desc).where(date_stopped: nil).limit(5).each do |medication| %>
+              <div class="box">
+                <div class="level is-flex-wrap-wrap" style="gap: 0.5rem;">
+                  <div class="level-left is-flex-grow-1" style="min-width: 0;">
+                    <div>
+                      <p class="has-text-weight-bold"><%= medication.name %></p>
+                      <p class="is-size-6"><%= medication.drug_class %></p>
+                      <p class="is-size-6 has-text-grey"><%= medication.doctor&.name %></p>
+                    </div>
+                  </div>
+                  <div class="level-right">
+                    <%= link_to "View", patient_medication_path(@patient, medication), class: "button is-info is-small" %>
                   </div>
                 </div>
-                <div class="level-right">
-                  <%= link_to "View", patient_medication_path(@patient, medication), class: "button is-info is-small" %>
-                </div>
               </div>
-            </div>
+            <% end %>
+          <% else %>
+            <p class="has-text-grey">No medications added yet.</p>
           <% end %>
-        <% else %>
-          <p class="has-text-grey">No medications added yet.</p>
-        <% end %>
+        </div>
       </div>
     </div>
 
     <%# Visits (placeholder) %>
     <div class="column">
-      <div class="box has-background-primary-95">
-        <h2 class="title is-4">Visits</h2>
-        <p class="has-text-grey">Coming soon.</p>
+      <div class="box has-background-primary-95" data-controller="collapsible" data-collapsible-key-value="visits">
+        <div class="level" style="cursor: pointer;" data-action="click->collapsible#toggle">
+          <div class="level-left">
+            <h2 class="title is-4"><span data-collapsible-target="icon" class="mr-2" style="font-weight: normal;">−</span>Visits</h2>
+          </div>
+        </div>
+        <div data-collapsible-target="content">
+          <p class="has-text-grey">Coming soon.</p>
+        </div>
       </div>
     </div>
 

--- a/spec/requests/collapsible_boxes_spec.rb
+++ b/spec/requests/collapsible_boxes_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'Collapsible boxes on patient show page', type: :request do
     expect(response.body).to include('data-collapsible-key-value="visits"')
   end
 
-  it 'wires the header row click to the toggle action' do
-    expect(response.body).to include('data-action="click->collapsible#toggle"')
+  it 'wires the header row click to the toggle action on all three sections' do
+    expect(response.body.scan('data-action="click->collapsible#toggle"').length).to eq(3)
   end
 
   it 'renders a collapsible content target for each section' do

--- a/spec/requests/collapsible_boxes_spec.rb
+++ b/spec/requests/collapsible_boxes_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Collapsible boxes on patient show page', type: :request do
   end
 
   it 'renders role=button on each section header' do
-    expect(response.body.scan('role="button"').length).to eq(3)
+    expect(response.body.scan(/role="button"[^>]*data-collapsible-target="header"|data-collapsible-target="header"[^>]*role="button"/).length).to eq(3)
   end
 
   it 'renders tabindex=0 on each section header' do

--- a/spec/requests/collapsible_boxes_spec.rb
+++ b/spec/requests/collapsible_boxes_spec.rb
@@ -17,14 +17,36 @@ RSpec.describe 'Collapsible boxes on patient show page', type: :request do
     expect(response.body).to include('data-controller="collapsible"')
   end
 
-  it 'sets the correct key values for each section' do
-    expect(response.body).to include('data-collapsible-key-value="doctors"')
-    expect(response.body).to include('data-collapsible-key-value="medications"')
-    expect(response.body).to include('data-collapsible-key-value="visits"')
+  it 'sets the doctors key scoped to the patient' do
+    expect(response.body).to include("data-collapsible-key-value=\"patient-#{patient.id}-doctors\"")
+  end
+
+  it 'sets the medications key scoped to the patient' do
+    expect(response.body).to include("data-collapsible-key-value=\"patient-#{patient.id}-medications\"")
+  end
+
+  it 'sets the visits key scoped to the patient' do
+    expect(response.body).to include("data-collapsible-key-value=\"patient-#{patient.id}-visits\"")
   end
 
   it 'wires the header row click to the toggle action on all three sections' do
-    expect(response.body.scan('data-action="click->collapsible#toggle"').length).to eq(3)
+    expect(response.body.scan('click->collapsible#toggle').length).to eq(3)
+  end
+
+  it 'wires the header row enter key to the toggle action on all three sections' do
+    expect(response.body.scan('keydown.enter->collapsible#toggle').length).to eq(3)
+  end
+
+  it 'wires the header row space key to the toggle action on all three sections' do
+    expect(response.body.scan('keydown.space->collapsible#toggle').length).to eq(3)
+  end
+
+  it 'renders the header target on each section' do
+    expect(response.body.scan('data-collapsible-target="header"').length).to eq(3)
+  end
+
+  it 'renders aria-expanded on each section header' do
+    expect(response.body.scan('aria-expanded="true"').length).to eq(3)
   end
 
   it 'renders a collapsible content target for each section' do
@@ -33,6 +55,14 @@ RSpec.describe 'Collapsible boxes on patient show page', type: :request do
 
   it 'renders an icon target for each section' do
     expect(response.body.scan('data-collapsible-target="icon"').length).to eq(3)
+  end
+
+  it 'renders role=button on each section header' do
+    expect(response.body.scan('role="button"').length).to eq(3)
+  end
+
+  it 'renders tabindex=0 on each section header' do
+    expect(response.body.scan('tabindex="0"').length).to eq(3)
   end
 
   it 'wires the action buttons to stop propagation' do

--- a/spec/requests/collapsible_boxes_spec.rb
+++ b/spec/requests/collapsible_boxes_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Collapsible boxes on patient show page', type: :request do
+  let(:user) { create(:user) }
+  let(:patient) { create(:patient, user: user) }
+
+  def sign_in
+    post session_path, params: { email_address: user.email_address, password: 'password123' }
+  end
+
+  before do
+    sign_in
+    get patient_path(patient)
+  end
+
+  it 'mounts the collapsible Stimulus controller on each section box' do
+    expect(response.body).to include('data-controller="collapsible"')
+  end
+
+  it 'sets the correct key values for each section' do
+    expect(response.body).to include('data-collapsible-key-value="doctors"')
+    expect(response.body).to include('data-collapsible-key-value="medications"')
+    expect(response.body).to include('data-collapsible-key-value="visits"')
+  end
+
+  it 'wires the header row click to the toggle action' do
+    expect(response.body).to include('data-action="click->collapsible#toggle"')
+  end
+
+  it 'renders a collapsible content target for each section' do
+    expect(response.body.scan('data-collapsible-target="content"').length).to eq(3)
+  end
+
+  it 'renders an icon target for each section' do
+    expect(response.body.scan('data-collapsible-target="icon"').length).to eq(3)
+  end
+
+  it 'wires the action buttons to stop propagation' do
+    expect(response.body).to include('collapsible#stopPropagation')
+  end
+end


### PR DESCRIPTION
Closes #32

## What

Adds the ability to collapse/expand the Doctors, Medications, and Visits section boxes on the patient show page so only the section header is visible when collapsed.

## How

- **New Stimulus controller** (`collapsible_controller.js`) — toggles `is-hidden` on the content area, persists collapsed/expanded state to `localStorage` per patient per section, and syncs `aria-expanded` on the header element.
- **New layout partial** (`patients/_section_box.html.erb`) — reusable wrapper that renders a collapsible box with a title, optional action buttons, and a content yield area.
- **Refactored `patients/show.html.erb`** — all three section boxes (Doctors, Medications, Visits) now use the partial.
- **New CSS** (`collapsible.scss`) — cursor, icon weight, and action button gap styles.

## Accessibility

- Header div has `role="button"`, `tabindex="0"`, and `aria-expanded` so it is reachable and operable via keyboard (Enter/Space) and readable by screen readers.
- `aria-expanded` is kept in sync by the Stimulus controller on every toggle.

## State persistence

`localStorage` keys are scoped per patient (`patient-{id}-doctors`, etc.) so collapsing a section on one patient does not affect another patient's view.

## Tests

Request spec (`spec/requests/collapsible_boxes_spec.rb`) asserts that the correct Stimulus data attributes, ARIA attributes, `role`, and `tabindex` are rendered in the HTML for all three sections.