### PR TITLE
Title: Add context-sensitive navbar links (closes #23)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
+  after_action :persist_current_patient, if: -> { @patient.present? }
 
   rescue_from Pundit::NotAuthorizedError, with: :pundit_not_authorized
 
@@ -27,5 +28,20 @@ class ApplicationController < ActionController::Base
 
   def pundit_user
     Current.user
+  end
+
+  def current_patient
+    return unless authenticated? && session[:current_patient_id].present?
+
+    @current_patient ||= begin
+      patient = Current.user.patients.find_by(id: session[:current_patient_id])
+      session[:current_patient_id] = nil unless patient
+      patient
+    end
+  end
+  helper_method :current_patient
+
+  def persist_current_patient
+    session[:current_patient_id] = @patient.id
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,8 @@ class ApplicationController < ActionController::Base
   after_action :verify_policy_scoped, only: :index
   after_action :persist_current_patient, if: -> { @patient.present? }
 
+  before_action :load_current_patient
+
   rescue_from Pundit::NotAuthorizedError, with: :pundit_not_authorized
 
   # Controllers that use allow_unauthenticated_access must also declare:
@@ -30,16 +32,12 @@ class ApplicationController < ActionController::Base
     Current.user
   end
 
-  def current_patient
+  def load_current_patient
     return unless authenticated? && session[:current_patient_id].present?
 
-    @current_patient ||= begin
-      patient = Current.user.patients.find_by(id: session[:current_patient_id])
-      session[:current_patient_id] = nil unless patient
-      patient
-    end
+    Current.patient = Current.user.patients.find_by(id: session[:current_patient_id])
+    session[:current_patient_id] = nil unless Current.patient
   end
-  helper_method :current_patient
 
   def persist_current_patient
     session[:current_patient_id] = @patient.id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
-  after_action :persist_current_patient, if: -> { @patient.present? }
+  after_action :persist_current_patient, if: -> { @patient.present? && @patient.persisted? }
 
   before_action :load_current_patient
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :session
+  attribute :patient
   delegate :user, to: :session, allow_nil: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,16 @@
         <% end %>
       </div>
       <div class="navbar-menu" data-navbar-target="menu">
+        <div class="navbar-start">
+          <% if authenticated? %>
+            <%= link_to "Patients", patients_path, class: "navbar-item" %>
+            <% if current_patient %>
+              <%= link_to current_patient.name, patient_path(current_patient), class: "navbar-item" %>
+              <%= link_to "Doctors", patient_doctors_path(current_patient), class: "navbar-item" %>
+              <%= link_to "Medications", patient_medications_path(current_patient), class: "navbar-item" %>
+            <% end %>
+          <% end %>
+        </div>
         <div class="navbar-end">
           <div class="navbar-item">
             <% if authenticated? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,10 +41,10 @@
         <div class="navbar-start">
           <% if authenticated? %>
             <%= link_to "Patients", patients_path, class: "navbar-item" %>
-            <% if current_patient %>
-              <%= link_to current_patient.name, patient_path(current_patient), class: "navbar-item" %>
-              <%= link_to "Doctors", patient_doctors_path(current_patient), class: "navbar-item" %>
-              <%= link_to "Medications", patient_medications_path(current_patient), class: "navbar-item" %>
+            <% if Current.patient %>
+              <%= link_to Current.patient.name, patient_path(Current.patient), class: "navbar-item" %>
+              <%= link_to "Doctors", patient_doctors_path(Current.patient), class: "navbar-item" %>
+              <%= link_to "Medications", patient_medications_path(Current.patient), class: "navbar-item" %>
             <% end %>
           <% end %>
         </div>

--- a/spec/requests/navbar_spec.rb
+++ b/spec/requests/navbar_spec.rb
@@ -74,5 +74,86 @@ RSpec.describe 'Navbar', type: :request do
     it 'shows the sign-out button' do
       expect(response.body).to include('Sign Out')
     end
+
+    it 'shows the Patients nav link' do
+      expect(response.body).to include(patients_path)
+    end
+
+    it 'does not show the Doctors nav link when no patient is selected' do
+      expect(response.body).not_to include('navbar-item">Doctors')
+    end
+
+    it 'does not show the Medications nav link when no patient is selected' do
+      expect(response.body).not_to include('navbar-item">Medications')
+    end
+  end
+
+  describe 'patient nav links' do
+    let(:patient) { create(:patient, user: user) }
+
+    before do
+      sign_in
+      get patient_path(patient) # sets session[:current_patient_id]
+      get patients_path # next request loads Current.patient from session
+    end
+
+    it 'shows the patient name in the navbar' do
+      expect(response.body).to include(patient.name)
+    end
+
+    it 'links the patient name to their show page' do
+      expect(response.body).to include(patient_path(patient))
+    end
+
+    it 'shows the Doctors nav link for the selected patient' do
+      expect(response.body).to include(patient_doctors_path(patient))
+    end
+
+    it 'shows the Medications nav link for the selected patient' do
+      expect(response.body).to include(patient_medications_path(patient))
+    end
+  end
+
+  describe 'session tracking' do
+    let(:patient) { create(:patient, user: user) }
+
+    before { sign_in }
+
+    it 'sets session[:current_patient_id] when visiting a patient show page' do
+      get patient_path(patient)
+      expect(session[:current_patient_id]).to eq(patient.id)
+    end
+
+    it 'sets session[:current_patient_id] when visiting a nested doctors route' do
+      get patient_doctors_path(patient)
+      expect(session[:current_patient_id]).to eq(patient.id)
+    end
+
+    it 'sets session[:current_patient_id] when visiting a nested medications route' do
+      get patient_medications_path(patient)
+      expect(session[:current_patient_id]).to eq(patient.id)
+    end
+
+    context 'when the session patient has been deleted' do
+      before do
+        get patient_path(patient) # sets session
+        patient.destroy
+      end
+
+      it 'clears the stale session key' do
+        get patients_path
+        expect(session[:current_patient_id]).to be_nil
+      end
+
+      it 'does not show the Doctors nav link' do
+        get patients_path
+        expect(response.body).not_to include(patient_doctors_path(patient))
+      end
+
+      it 'does not show the Medications nav link' do
+        get patients_path
+        expect(response.body).not_to include(patient_medications_path(patient))
+      end
+    end
   end
 end

--- a/spec/requests/navbar_spec.rb
+++ b/spec/requests/navbar_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe 'Navbar', type: :request do
   end
 
   describe 'authenticated layout' do
+    let!(:patient) { create(:patient, user: user) }
+
     before do
       sign_in
       get patients_path
@@ -80,11 +82,11 @@ RSpec.describe 'Navbar', type: :request do
     end
 
     it 'does not show the Doctors nav link when no patient is selected' do
-      expect(response.body).not_to include('navbar-item">Doctors')
+      expect(response.body).not_to include(patient_doctors_path(patient))
     end
 
     it 'does not show the Medications nav link when no patient is selected' do
-      expect(response.body).not_to include('navbar-item">Medications')
+      expect(response.body).not_to include(patient_medications_path(patient))
     end
   end
 


### PR DESCRIPTION
Populates the navbar when authenticated:
- Always shows a **Patients** link
- When a patient is selected (tracked via `session[:current_patient_id]`), also shows the patient name, **Doctors**, and **Medications** links
- Links appear inside the hamburger menu on mobile via Bulma's `navbar-menu`

**Implementation:**
- `Current.patient` attribute on `CurrentAttributes`
- `load_current_patient` before-action: scopes the session lookup through `Current.user.patients` (ownership-safe)
- `persist_current_patient` after-action: fires only when `@patient.persisted?` — correctly skips new/unsaved patients and destroyed patients

Fixes: #23