### PR TITLE
fix: populate navbar on first patient select with no session cookie

### DIFF
--- a/app/controllers/doctors_controller.rb
+++ b/app/controllers/doctors_controller.rb
@@ -51,6 +51,7 @@ class DoctorsController < ApplicationController
 
   def set_patient
     @patient = Current.user.patients.find(params[:patient_id])
+    Current.patient = @patient
   end
 
   def set_doctor

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -65,6 +65,7 @@ class MedicationsController < ApplicationController
 
   def set_patient
     @patient = Current.user.patients.find(params[:patient_id])
+    Current.patient = @patient
   end
 
   def set_medication

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -47,6 +47,7 @@ class PatientsController < ApplicationController
 
   def set_patient
     @patient = Current.user.patients.find(params[:id])
+    Current.patient = @patient
   end
 
   def patient_params

--- a/spec/requests/navbar_spec.rb
+++ b/spec/requests/navbar_spec.rb
@@ -93,26 +93,47 @@ RSpec.describe 'Navbar', type: :request do
   describe 'patient nav links' do
     let(:patient) { create(:patient, user: user) }
 
-    before do
-      sign_in
-      get patient_path(patient) # sets session[:current_patient_id]
-      get patients_path # next request loads Current.patient from session
+    context 'when visiting a patient page for the first time (no prior session cookie)' do
+      before do
+        sign_in
+        get patient_path(patient)
+      end
+
+      it 'shows the patient name in the navbar immediately' do
+        expect(response.body).to include(patient.name)
+      end
+
+      it 'shows the Doctors nav link immediately' do
+        expect(response.body).to include(patient_doctors_path(patient))
+      end
+
+      it 'shows the Medications nav link immediately' do
+        expect(response.body).to include(patient_medications_path(patient))
+      end
     end
 
-    it 'shows the patient name in the navbar' do
-      expect(response.body).to include(patient.name)
-    end
+    context 'when revisiting after a session has been established' do
+      before do
+        sign_in
+        get patient_path(patient) # sets session[:current_patient_id]
+        get patients_path # next request loads Current.patient from session
+      end
 
-    it 'links the patient name to their show page' do
-      expect(response.body).to include(patient_path(patient))
-    end
+      it 'shows the patient name in the navbar' do
+        expect(response.body).to include(patient.name)
+      end
 
-    it 'shows the Doctors nav link for the selected patient' do
-      expect(response.body).to include(patient_doctors_path(patient))
-    end
+      it 'links the patient name to their show page' do
+        expect(response.body).to include(patient_path(patient))
+      end
 
-    it 'shows the Medications nav link for the selected patient' do
-      expect(response.body).to include(patient_medications_path(patient))
+      it 'shows the Doctors nav link for the selected patient' do
+        expect(response.body).to include(patient_doctors_path(patient))
+      end
+
+      it 'shows the Medications nav link for the selected patient' do
+        expect(response.body).to include(patient_medications_path(patient))
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #64

### Root cause

`load_current_patient` (a `before_action` in `ApplicationController`) runs **before** the subclass `set_patient` before_action. On a fresh login with no `session[:current_patient_id]`, `Current.patient` remains `nil` for the entire request — the view renders with the navbar links missing. The `persist_current_patient` after_action writes the patient id to the session *after* the view has already rendered, so only subsequent requests benefit.

### Fix

Set `Current.patient = @patient` inside `set_patient` in each controller (`PatientsController`, `DoctorsController`, `MedicationsController`). This guarantees `Current.patient` is populated for the current request regardless of session state.

### Tests

Added a `when visiting a patient page for the first time` context to `spec/requests/navbar_spec.rb` that reproduces the exact repro steps from the issue (sign in → visit patient → assert navbar renders patient name and nav links on that same response). Also restructured the existing "patient nav links" examples into a proper `context` block.